### PR TITLE
Fix GL_INVALID_ENUM errors

### DIFF
--- a/src/glxosd/OSDInstance.cpp
+++ b/src/glxosd/OSDInstance.cpp
@@ -250,8 +250,8 @@ void OSDInstance::render(unsigned int width, unsigned int height) {
 	rgl(ActiveTexture)(GL_TEXTURE0);
 	rgl(GetIntegerv)(GL_SAMPLER_BINDING, &samplerBinding);
 	
-	rgl(BindFramebuffer)(GL_DRAW_FRAMEBUFFER_BINDING, 0);
-	rgl(BindFramebuffer)(GL_READ_FRAMEBUFFER_BINDING, 0);
+	rgl(BindFramebuffer)(GL_DRAW_FRAMEBUFFER, 0);
+	rgl(BindFramebuffer)(GL_READ_FRAMEBUFFER, 0);
 	rgl(PolygonMode)(GL_FRONT_AND_BACK, GL_FILL);
 	
 	renderText(width, height);
@@ -267,8 +267,8 @@ void OSDInstance::render(unsigned int width, unsigned int height) {
 	rgl(BindBuffer)(GL_PIXEL_UNPACK_BUFFER, pixelUnpackBufferBinding);
 	rgl(BindBuffer)(GL_ARRAY_BUFFER, arrayBufferBinding);
 	rgl(BindBuffer)(GL_ELEMENT_ARRAY_BUFFER, elementArrayBufferBinding);
-	rgl(BindFramebuffer)(GL_DRAW_FRAMEBUFFER_BINDING, drawFramebufferBinding);
-	rgl(BindFramebuffer)(GL_READ_FRAMEBUFFER_BINDING, readFramebufferBinding);
+	rgl(BindFramebuffer)(GL_DRAW_FRAMEBUFFER, drawFramebufferBinding);
+	rgl(BindFramebuffer)(GL_READ_FRAMEBUFFER, readFramebufferBinding);
 	
 	rgl(PolygonMode)(GL_FRONT_AND_BACK, glPolygonModeFrontAndBack);
 


### PR DESCRIPTION
Correct usage of glBindFrameBuffer.

[1] https://www.opengl.org/sdk/docs/man/html/glGet.xhtml
[2] https://www.opengl.org/sdk/docs/man/html/glBindFramebuffer.xhtml