### PR TITLE
Added keybinding to toggle VSync

### DIFF
--- a/conf/glxosd.conf
+++ b/conf/glxosd.conf
@@ -75,6 +75,9 @@ text_spacing_y_float = 0
 # Alt+Shift+TAB
 osd_toggle_keycombo = "Shift+F10"
 
+# Key for toggling VSync
+vsync_toggle_keycombo = "Shift+F11"
+
 # Key combo for toggling frame logging. Pressing this key will start/stop frame timing logging.
 # You can leave this blank to disable this key combo.
 # Please see osd_toggle_keycombo for documentation on the format of this property. 

--- a/src/glxosd/OSDInstance.cpp
+++ b/src/glxosd/OSDInstance.cpp
@@ -250,8 +250,8 @@ void OSDInstance::render(unsigned int width, unsigned int height) {
 	rgl(ActiveTexture)(GL_TEXTURE0);
 	rgl(GetIntegerv)(GL_SAMPLER_BINDING, &samplerBinding);
 	
-	rgl(BindFramebuffer)(GL_DRAW_FRAMEBUFFER_BINDING, 0);
-	rgl(BindFramebuffer)(GL_READ_FRAMEBUFFER_BINDING, 0);
+	rgl(BindFramebuffer)(GL_DRAW_FRAMEBUFFER, 0);
+	rgl(BindFramebuffer)(GL_READ_FRAMEBUFFER, 0);
 	rgl(PolygonMode)(GL_FRONT_AND_BACK, GL_FILL);
 	
 	renderText(width, height);
@@ -267,8 +267,8 @@ void OSDInstance::render(unsigned int width, unsigned int height) {
 	rgl(BindBuffer)(GL_PIXEL_UNPACK_BUFFER, pixelUnpackBufferBinding);
 	rgl(BindBuffer)(GL_ARRAY_BUFFER, arrayBufferBinding);
 	rgl(BindBuffer)(GL_ELEMENT_ARRAY_BUFFER, elementArrayBufferBinding);
-	rgl(BindFramebuffer)(GL_DRAW_FRAMEBUFFER_BINDING, drawFramebufferBinding);
-	rgl(BindFramebuffer)(GL_READ_FRAMEBUFFER_BINDING, readFramebufferBinding);
+	rgl(BindFramebuffer)(GL_DRAW_FRAMEBUFFER, drawFramebufferBinding);
+	rgl(BindFramebuffer)(GL_READ_FRAMEBUFFER, readFramebufferBinding);
 	
 	rgl(PolygonMode)(GL_FRONT_AND_BACK, glPolygonModeFrontAndBack);
 


### PR DESCRIPTION
This is not really a "pull request" in that I expect you to pull it - I'm not sure if this feature is useful enough to warrant inclusion. I figured posting here anyway in case other people are interested.

I added the keybinding because of a frustrating bug in Metro 2033: Redux; for some reason the game would toggle VSync off whenever I alt-tab to the desktop, with no way to turn VSync back on through the ingame UI.