### PR TITLE
Remove unnecessary X includes for Bug #20

### DIFF
--- a/src/glxosd-libsensors-support/LibsensorsSensorDataProvider.cpp
+++ b/src/glxosd-libsensors-support/LibsensorsSensorDataProvider.cpp
@@ -13,6 +13,8 @@
 #include "ConfigurationManager.hpp"
 #include "Utils.hpp"
 #include <boost/format.hpp>
+// workaround X.h clash with Boost-xpressive < 1.53 (https://svn.boost.org/trac/boost/ticket/8204)
+#undef None
 #include <boost/xpressive/xpressive.hpp>
 #include <sensors/sensors.h>
 #include <sstream>

--- a/src/glxosd/ConfigurationManager.cpp
+++ b/src/glxosd/ConfigurationManager.cpp
@@ -10,8 +10,6 @@
 
 #include "ConfigurationManager.hpp"
 #include "Utils.hpp"
-#include <X11/Xlib.h>
-#include <X11/keysym.h>
 #include <boost/format.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/xpressive/xpressive.hpp>


### PR DESCRIPTION
Remove unnecessary X includes to workaround "#define None" clash with boost-xpressive < 1.53 (Bug #20)

More details on https://github.com/nickguletskii/GLXOSD/issues/20#issuecomment-138106030