### PR TITLE
Use the GLX drawable dimensions instead of GL_VIEWPORT

### DIFF
--- a/src/glxosd/GLXOSD.cpp
+++ b/src/glxosd/GLXOSD.cpp
@@ -130,14 +130,14 @@ void GLXOSD::osdHandleBufferSwap(Display* display, GLXDrawable drawable) {
 		glXQueryDrawable(display, drawable, GLX_WIDTH, &windowWidth);
 		glXQueryDrawable(display, drawable, GLX_HEIGHT, &windowHeight);
 
+		if (windowWidth < 1 || windowHeight < 1) {
+			return;
+		}
+
 		GLint viewport[4];
 		rgl(GetIntegerv)(GL_VIEWPORT, viewport);
 
 		rgl(Viewport)(0, 0, windowWidth, windowHeight);
-
-		if (windowWidth < 1 || windowHeight < 1) {
-			return;
-		}
 
 		instance->render(windowWidth, windowHeight);
 

--- a/src/glxosd/GLXOSD.cpp
+++ b/src/glxosd/GLXOSD.cpp
@@ -101,9 +101,6 @@ void GLXOSD::osdHandleBufferSwap(Display* display, GLXDrawable drawable) {
 	osdToggledThisFrame = false;
 	frameLogToggledThisFrame = false;
 
-	unsigned int width = 1;
-	unsigned int height = 1;
-
 	if (toggleVsync)
 	{
 		unsigned int swapInterval;
@@ -129,16 +126,22 @@ void GLXOSD::osdHandleBufferSwap(Display* display, GLXDrawable drawable) {
 			instance = (*it).second;
 		}
 		GlinjectGLLockRAIIHelper raiiHelper;
+		unsigned int windowWidth = 0, windowHeight = 0;
+		glXQueryDrawable(display, drawable, GLX_WIDTH, &windowWidth);
+		glXQueryDrawable(display, drawable, GLX_HEIGHT, &windowHeight);
+
 		GLint viewport[4];
 		rgl(GetIntegerv)(GL_VIEWPORT, viewport);
-		width = viewport[2];
-		height = viewport[3];
 
-		if (width < 1 || height < 1) {
+		rgl(Viewport)(0, 0, windowWidth, windowHeight);
+
+		if (windowWidth < 1 || windowHeight < 1) {
 			return;
 		}
 
-		instance->render(width, height);
+		instance->render(windowWidth, windowHeight);
+
+		rgl(Viewport)(viewport[0], viewport[1], viewport[2], viewport[3]);
 	}
 
 	if (isFrameLoggingEnabled()) {


### PR DESCRIPTION
glViewport may not be set to the actual window dimensions, e.g. for split screen games, or if the game's state tracker just likes to reset state to its default after it's done rendering.

This fixes the overlay positioning in OpenSceneGraph-based applications, e.g. OpenMW.