### PR TITLE
Fix reset of GL_TEXTURE_BINDING_2D

### DIFF
--- a/src/glxosd/OSDInstance.cpp
+++ b/src/glxosd/OSDInstance.cpp
@@ -235,7 +235,6 @@ void OSDInstance::render(unsigned int width, unsigned int height) {
 			&pixelUnpackBufferBinding);
 	rgl(GetIntegerv)(GL_ARRAY_BUFFER_BINDING, &arrayBufferBinding);
 	rgl(GetIntegerv)(GL_ACTIVE_TEXTURE, &activeTexture);
-	rgl(GetIntegerv)(GL_TEXTURE_BINDING_2D, &textureBinding2D);
 	rgl(GetIntegerv)(GL_VERTEX_ARRAY_BINDING, &vertexArrayBinding);
 	rgl(GetIntegerv)(GL_ELEMENT_ARRAY_BUFFER_BINDING,
 			&elementArrayBufferBinding);
@@ -249,6 +248,7 @@ void OSDInstance::render(unsigned int width, unsigned int height) {
 	//We are borrowing GL_TEXTURE0, so we need to reset its sampler
 	rgl(ActiveTexture)(GL_TEXTURE0);
 	rgl(GetIntegerv)(GL_SAMPLER_BINDING, &samplerBinding);
+	rgl(GetIntegerv)(GL_TEXTURE_BINDING_2D, &textureBinding2D);
 	
 	rgl(BindFramebuffer)(GL_DRAW_FRAMEBUFFER_BINDING, 0);
 	rgl(BindFramebuffer)(GL_READ_FRAMEBUFFER_BINDING, 0);
@@ -259,10 +259,10 @@ void OSDInstance::render(unsigned int width, unsigned int height) {
 	//Revert sampler
 	rgl(ActiveTexture)(GL_TEXTURE0);
 	rgl(BindSampler)(0, samplerBinding);
-	
+	rgl(BindTexture)(GL_TEXTURE_2D, textureBinding2D);
+
 	//Revert buffer states
 	rgl(ActiveTexture)(activeTexture);
-	rgl(BindTexture)(GL_TEXTURE_2D, textureBinding2D);
 	rgl(BindVertexArray)(vertexArrayBinding);
 	rgl(BindBuffer)(GL_PIXEL_UNPACK_BUFFER, pixelUnpackBufferBinding);
 	rgl(BindBuffer)(GL_ARRAY_BUFFER, arrayBufferBinding);


### PR DESCRIPTION
GLXOSD was changing the texture binding for texture unit 0, then afterwards resetting it for the previously active texture unit instead of the texture unit we modified.

This fixes the intro video corruption in XCOM (https://github.com/nickguletskii/GLXOSD/issues/19#issuecomment-138137600) and Outlast (#46).