### PR TITLE
Don't render in the first frame

### DIFF
--- a/src/glxosd/OSDInstance.cpp
+++ b/src/glxosd/OSDInstance.cpp
@@ -27,6 +27,7 @@
 namespace glxosd {
 
 OSDInstance::OSDInstance() :
+		firstFrame(true),
 		renderer(nullptr),
 		osdText("Gathering data...") {
 	const ConfigurationManager &configurationManager =
@@ -138,6 +139,14 @@ void OSDInstance::renderText(unsigned int width, unsigned int height) {
 }
 
 void OSDInstance::render(unsigned int width, unsigned int height) {
+	if (firstFrame)
+	{
+		// Don't render in the first frame. This is an attempt to prevent rendering on game
+		// launchers and splash screens were benchmarking is not desired.
+		firstFrame = false;
+		return;
+	}
+
 	currentFrameCount++;
 	long currentTimeMilliseconds = getMonotonicTimeNanoseconds() / 1000000ULL;
 //Refresh the info every 500 milliseconds

--- a/src/glxosd/OSDInstance.hpp
+++ b/src/glxosd/OSDInstance.hpp
@@ -21,6 +21,7 @@ class ConfigurationManager;
 class FontRenderer;
 class OSDInstance {
 private:
+	bool firstFrame;
 	int currentFrameCount; // The number of frames from the last FPS calculation
 	uint64_t previousTime; //The time of the previous FPS calculation
 	double framesPerSecond; //Current FPS


### PR DESCRIPTION
This is an attempt to prevent rendering on game launchers and splash screens were benchmarking is not desired.

For some reason, this change also fixes the overlay not appearing in the actual game window in Outlast (#46). I have no idea why!