### PR TITLE
Dont override GLXOSD_PRELOAD

### DIFF
--- a/launcher_template.sh
+++ b/launcher_template.sh
@@ -12,7 +12,6 @@ function showHelp() {
 OPTIND=1
 
 INJECT_STEAM_OVERLAY=false
-GLXOSD_PRELOAD=""
 STEAM_PATH=~/.local/share/Steam
 
 while : ; do


### PR DESCRIPTION
The help text states "GLXOSD_PRELOAD will be in LD_PRELOAD before GLXOSD libraries" but it is set to nothing at the top of the file. Probable an erroneous initialisation.

fyi: I have https://github.com/sickill/stderred in my LD_PRELOAD. With this in there anything run via glxosd was crashing at link time. Setting `LD_DEBUG` and `LD_VERBOSE` the last method printed was regarding binding `fwrite_unlocked`. Preloading `libstderred.so` before the glxosd stuff makes things not crash. I assume that means they are not being good LD_PRELOAD citizens or something.