### PR TITLE
use 'exec' in glxosd launcher

### DIFF
--- a/launcher_template.sh.in
+++ b/launcher_template.sh.in
@@ -57,4 +57,4 @@ export LD_PRELOAD="${GLXOSD_PRELOAD}:${STEAM_OVERLAY_LIBS}:libglxosd-glinject.so
 export GLXOSD_SCRIPTS_ROOT
 export GLXOSD_ADDITIONAL_CONFIG_LOCATION
 
-"$@"
+exec "$@"


### PR DESCRIPTION
This doesn't leave an extra process hanging, instead replaces the
original process with the new launched one.

Fixes #89.
